### PR TITLE
Validate models which have not unsupported Negative prompt

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -9,7 +9,7 @@ const MODEL_NAMES = {
 
 const UNSUPPORTED_NEGATIVE_PROMP_MODELS = [MODEL_NAMES.SD3_LARGE_TURBO];
 
-async function image_generation_via_stable_diffusion_3_7659225(params, userSettings) {
+async function image_generation_via_stable_diffusion_3(params, userSettings) {
   const { prompt, negative_prompt } = params;
   const { stabilityAPIKey, output_format, aspect_ratio, model } = userSettings;
   validateAPIKey(stabilityAPIKey);

--- a/implementation.js
+++ b/implementation.js
@@ -18,7 +18,7 @@ async function image_generation_via_stable_diffusion_3(params, userSettings) {
   let requestNegativePrompt = negative_prompt;
   if (negative_prompt && UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model)) {
     requestNegativePrompt = undefined;
-    requestPrompt = `${requestPrompt} Do not include ${requestNegativePrompt}`
+    requestPrompt = `${requestPrompt} Do not include ${negative_prompt}`
   }
 
   try {

--- a/implementation.js
+++ b/implementation.js
@@ -1,7 +1,19 @@
+const MODEL_NAMES = {
+  SD3_5_MEDIUM: 'sd3.5-medium',
+  SD3_5_LARGE: 'sd3.5-large',
+  SD3_5_LARGE_TURBO: 'sd3.5-large-turbo',
+  SD3_MEDIUM: 'sd3-medium',
+  SD3_LARGE: 'sd3-large',
+  SD3_LARGE_TURBO: 'sd3-large-turbo',
+};
+
+const UNSUPPORTED_NEGATIVE_PROMP_MODELS = [MODEL_NAMES.SD3_LARGE_TURBO];
+
 async function image_generation_via_stable_diffusion_3(params, userSettings) {
   const { prompt, negative_prompt } = params;
   const { stabilityAPIKey, output_format, aspect_ratio, model } = userSettings;
   validateAPIKey(stabilityAPIKey);
+  validateNegativePrompt(model, negative_prompt);
 
   try {
     const imageData = await generateImageFromStabilityAPI(
@@ -11,14 +23,24 @@ async function image_generation_via_stable_diffusion_3(params, userSettings) {
         output_format,
         aspect_ratio,
         model,
-        negative_prompt
+        negative_prompt: UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model) ? negative_prompt : undefined,
       }
     );
-
     return imageData;
   } catch (error) {
     console.error('Error generating image:', error);
     throw new Error('Error: ' + error.message);
+  }
+}
+
+function isNonEmptyString(param) {
+  return typeof param === 'string' && param.trim() !== '';
+}
+
+function validateNegativePrompt(model, negative_prompt) {
+  // Validate negative prompt available with selected model  
+  if (UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model) && isNonEmptyString(negative_prompt)) {
+    throw new Error(`Negative prompts are not supported with ${model} model. Please select a different model in the Plugin User Settings.`) 
   }
 }
 

--- a/implementation.js
+++ b/implementation.js
@@ -14,16 +14,22 @@ async function image_generation_via_stable_diffusion_3(params, userSettings) {
   const { stabilityAPIKey, output_format, aspect_ratio, model } = userSettings;
   validateAPIKey(stabilityAPIKey);
   validateNegativePrompt(model, negative_prompt);
-
+  let requestPrompt = prompt;
+  let requestNegativePrompt = negative_prompt;
+  if (negative_prompt && UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model)) {
+    requestNegativePrompt = undefined;
+    requestPrompt = `${requestPrompt} Do not include ${requestNegativePrompt}`
+  }
+  
   try {
     const imageData = await generateImageFromStabilityAPI(
       stabilityAPIKey,
-      prompt,
+      requestPrompt,
       {
         output_format,
         aspect_ratio,
         model,
-        negative_prompt: UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model) ? negative_prompt : undefined,
+        negative_prompt: requestNegativePrompt,
       }
     );
     return imageData;

--- a/implementation.js
+++ b/implementation.js
@@ -9,18 +9,18 @@ const MODEL_NAMES = {
 
 const UNSUPPORTED_NEGATIVE_PROMP_MODELS = [MODEL_NAMES.SD3_LARGE_TURBO];
 
-async function image_generation_via_stable_diffusion_3(params, userSettings) {
+async function image_generation_via_stable_diffusion_3_7659225(params, userSettings) {
   const { prompt, negative_prompt } = params;
   const { stabilityAPIKey, output_format, aspect_ratio, model } = userSettings;
   validateAPIKey(stabilityAPIKey);
-  validateNegativePrompt(model, negative_prompt);
+  
   let requestPrompt = prompt;
   let requestNegativePrompt = negative_prompt;
   if (negative_prompt && UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model)) {
     requestNegativePrompt = undefined;
     requestPrompt = `${requestPrompt} Do not include ${requestNegativePrompt}`
   }
-  
+
   try {
     const imageData = await generateImageFromStabilityAPI(
       stabilityAPIKey,
@@ -36,17 +36,6 @@ async function image_generation_via_stable_diffusion_3(params, userSettings) {
   } catch (error) {
     console.error('Error generating image:', error);
     throw new Error('Error: ' + error.message);
-  }
-}
-
-function isNonEmptyString(param) {
-  return typeof param === 'string' && param.trim() !== '';
-}
-
-function validateNegativePrompt(model, negative_prompt) {
-  // Validate negative prompt available with selected model  
-  if (UNSUPPORTED_NEGATIVE_PROMP_MODELS.includes(model) && isNonEmptyString(negative_prompt)) {
-    throw new Error(`Negative prompts are not supported with ${model} model. Please select a different model in the Plugin User Settings.`) 
   }
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -40,8 +40,15 @@
       "label": "Model to use for generation",
       "description": "Optional, default: \"sd3-large\"",
       "type": "enum",
-      "values": ["sd3-medium", "sd3-large", "sd3-large-turbo"],
-      "defaultValue": "sd3-large"
+      "values": [
+        "sd3.5-medium",
+        "sd3.5-large",
+        "sd3.5-large-turbo",
+        "sd3-medium",
+        "sd3-large",
+        "sd3-large-turbo"
+      ], 
+      "defaultValue": "sd3.5-medium"
     }
   ],
   "iconURL": "https://www.typingmind.com/stable-diffusion.png",

--- a/plugin.json
+++ b/plugin.json
@@ -57,7 +57,10 @@
     "name": "image_generation_via_stable_diffusion_3",
     "parameters": {
       "type": "object",
-      "required": ["prompt"],
+      "required": [
+        "prompt",
+        "negative_prompt"
+      ],
       "properties": {
         "prompt": {
           "type": "string",
@@ -65,7 +68,7 @@
         },
         "negative_prompt": {
           "type": "string",
-          "description": "A blurb of text describing what you do not wish to see in the output image. Include only if the user asks for it."
+          "description": "A blurb of text describing what you do not wish to see in the output image. Include only if the user asks for it. Default value is empty string. If negative_prompt not supported when current model is 'sd3-large-turbo', combine negative_prompt into prompt and set the negative_prompt to empty string. Re-generate image when current model not supported negative_prompt."
         }
       }
     },


### PR DESCRIPTION
Changes:
- Refactor implementation code with model constant.
- Add validation logic for checking model did not support negative prompt.
- Update latest model list to user settings

Preview Images:
![Screenshot 2025-01-09 at 09 56 29](https://github.com/user-attachments/assets/6e900be1-ff36-4281-aba6-65e23a9dc944)

![Screenshot 2025-01-09 at 09 47 59](https://github.com/user-attachments/assets/97a887d5-80b4-443f-9d69-fb6ea0029562)
